### PR TITLE
DS-3583: Ensure LDA stores factor levels as list

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -60,7 +60,7 @@ prepareMachineLearningData <- function(formula, data, subset, subset.description
 
     if (dummy)
     {
-        factor.levels <- sapply(data[, -outcome.i], levels)
+        factor.levels <- lapply(data[, -outcome.i], levels)
         # convert factors with N levels to N-1 binary variables, used by LDA
         data <- cbind(data[outcome.i], AsNumeric(data[, -outcome.i, drop = FALSE], binary = TRUE, remove.first = TRUE))
         # remove constant variables caused by unpopulated levels

--- a/tests/testthat/test-lineardiscriminantanalysis.R
+++ b/tests/testthat/test-lineardiscriminantanalysis.R
@@ -264,3 +264,10 @@ test_that("Output contains the right class for extension buttons", {
 })
 
 # In SPSS, the priors are always the oberved priors when fitting the model. In MASS:lda, the priors are used when fitting.
+
+# Ensure that factor levels are not being converted to a matrix. DS-3583
+test_that("Factor level info stored as list", {
+    data(colas, package = "flipExampleData")
+    expect_warning(zLDA <- LDA(q3 ~ Q5_5_1 + Q5_7_1 + Q5_13_1, data = colas, prior = "Observed"), "smallest category of the outcome")
+    expect_type(zLDA$factor.levels, "list")
+})


### PR DESCRIPTION
Factor levels were being coerced to matrix by use of sapply. This was causing an error when using predict.LDA.