### PR TITLE
Untracked: Fix Nix build warnings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,10 +33,12 @@ Imports:
     verbs
 Suggests:
     Ckmeans.1d.dp,
+    flipDevTools,
     testthat,
     flipExampleData
 Remotes:
     Displayr/flipAnalysisOfVariance,
+    Displayr/flipDevTools,
     Displayr/flipChartBasics,
     Displayr/flipData,
     Displayr/flipExampleData,

--- a/man/MachineLearningEnsemble.Rd
+++ b/man/MachineLearningEnsemble.Rd
@@ -32,7 +32,7 @@ training weights.}
 
 \item{output}{If \code{compare.only} is \code{FALSE}, one of \code{"Comparison"} which
 produces a table comparing the models, or \code{"Ensemble"} which produces a
-\code{\link{ConfusionMatrix}}.}
+\code{\link[flipRegression]{ConfusionMatrix}}.}
 
 \item{optimal.ensemble}{Logical; whether to find the ensemble with the best accuracy or
 r-squared, calculated on the \code{evaluation.subset} if given, else on the training

--- a/man/MachineLearningMulti.Rd
+++ b/man/MachineLearningMulti.Rd
@@ -62,7 +62,7 @@ data. Ignored if \code{compare.only} is TRUE.}
 
 \item{output}{If \code{compare.only} is \code{FALSE}, one of \code{"Comparison"} which
 produces a table comparing the models, or \code{"Ensemble"} which produces a
-\code{\link{ConfusionMatrix}}.}
+\code{\link[flipRegression]{ConfusionMatrix}}.}
 }
 \description{
 Create an ensemble or comparison table of new MachineLearning and/or Regression models

--- a/man/RandomForest.Rd
+++ b/man/RandomForest.Rd
@@ -48,7 +48,7 @@ variables label is an attribute (e.g., attr(foo, "label")).}
 \item{sort.by.importance}{Sort the last column of the importance table
 in descending order.}
 
-\item{...}{Other arguments to be supplied to \code{\link{randomForest}}.}
+\item{...}{Other arguments to be supplied to \code{\link[randomForest]{randomForest}}.}
 }
 \description{
 Fit a random forest model

--- a/man/SupportVectorMachine.Rd
+++ b/man/SupportVectorMachine.Rd
@@ -51,7 +51,7 @@ name of a variable in \code{data}. It may not be an expression.}
 \item{show.labels}{Shows the variable labels, as opposed to the labels, in the outputs, where a
 variables label is an attribute (e.g., attr(foo, "label")).}
 
-\item{...}{Other arguments to be supplied to \code{\link{svm}}.}
+\item{...}{Other arguments to be supplied to \code{\link[e1071]{svm}}.}
 }
 \description{
 Fit a support vector machine model


### PR DESCRIPTION
Unfortunately doesn't make the build pass, as the tests are failing with an error saying that the python tensorflow package isn't installed.
From Jordan:
> Unfortunately our Python dependencies are not handled by Nix, because the oldest version of Python Nix supports is 3.9, and we use 3.8 for our R packages, and on the R Server. We tried updating Python to 3.9 so it could be handled via Nix, but that created a dependency hell situation where some Python packages don't support 3.9 (or newer) without a major update, which when we performed that update, resulted in multiple internal R packages having API breakages. Justin W and I are working on that as a low priority task.